### PR TITLE
[WIP] Update run.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Simple docker container for [MicroMDM][1].  MicroMDM is simple to run, as it is 
 
 There are at least 2 folders you would want to map into the container (or use a data container for).  You can easily migrate from a dedicated instance to a dockerized version by pointing the container to your pre-existing folders.
 
-For the `/certs` folder we expect:
+For the certificates we use defaults of :
 ```
 /certs
-  mdm_push_cert.pem
-  ProviderPrivateKey.key
+  /certs/mdm_push_cert.pem
+  /certs/ProviderPrivateKey.key
 ```
-Rename your APNS files to match above when passing through to the container.  This folder also will contain your own TLS cert and key file if you opt to use one.  The `TLS_CERT` and `TLS_KEY` environment variable should match the name of the file(s) that you places in the `/certs` folder.
+Use this folder also will contain your own TLS cert and key file if you opt to use one.  The `TLS_CERT` and `TLS_KEY` environment variable should match the name of the file(s) that you places in the `/certs` folder.
 
 You can see the logs of the running container by using `docker logs` for example:
 ```

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-
 # we are going to require the following ENV variables:
 #   APNS_PASSWORD
 #   SERVER_URL
@@ -17,15 +16,14 @@
 
 # Set Environmental VARS.
 
-
-APNS_CERT=${APNS_CERT:'/certs/mdm_push_cert.pem'}
-APNS_PASSWORD=${APNS_PASSWORD}
-APNS_KEY=${APNS_KEY:'/certs/ProviderPrivateKey.key'}
-TLS_CERT=${TLS_CERT:'/certs/tls.pem'}
-TLS_KEY=${TLS_KEY:'/certs/tls.key'}
-FILE_REPO=${REPO:'/repo'}
-CONFIG_PATH=${CONFIG_PATH:'/config'}
-SERVER_URL=${SERVER_URL}
+APNS_CERT="${APNS_CERT:-'/certs/mdm_push_cert.pem'}"
+APNS_PASSWORD="${APNS_PASSWORD}"
+APNS_KEY="${APNS_KEY:-'/certs/ProviderPrivateKey.key'}"
+TLS_CERT="${TLS_CERT:-'/certs/tls.pem'}"
+TLS_KEY="${TLS_KEY:-'/certs/tls.key'}"
+FILE_REPO="${REPO:-'/repo'}"
+CONFIG_PATH="${CONFIG_PATH:-'/config'}"
+SERVER_URL="${SERVER_URL}"
 
 # Perform Quick Check.
 
@@ -58,7 +56,7 @@ if [[ ${API_KEY} ]]; then
 fi
 
 # process TLS settings
-if [[ ${TLS} = true ]]; then
+if [[ ${TLS} == true ]]; then
   if [[ ! -z "${TLS_CERT}" && ! -z ${TLS_KEY} && -e "${TLS_CERT}" && -e "${TLS_KEY}" ]]; then
     runMicroMDM="${runMicroMDM} \
       -tls-cert '${TLS_CERT}' \


### PR DESCRIPTION
# Description

The following PR adds support for using certificates etc which do not have standard naming plus supporting all known flags of MicroMDM. 

The reason for this is just to add some additional flexibility to the usage of this container. 

## To Do
- [x] Ensure all Vars are configurable 
- [x] Where appropriate create necessary checks such as P12 cert use password PEM use key etc. 
- [x] Lint properly using shfmt ensure proper execution using -e & shellcheck pass